### PR TITLE
Modified retrieval of version info to fix install issue.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
-import huxley
 from setuptools import setup, find_packages
 import os
 
 DIRNAME = os.path.dirname(os.path.abspath(__file__))
 
+execfile(os.path.join(DIRNAME, 'huxley', 'version.py'))
+
 setup(
     name = 'Huxley',
-    version = huxley.__version__,
+    version = __version__,
     packages = find_packages(),
     install_requires = [
         'selenium==2.32.0',


### PR DESCRIPTION
If you try to install huxley within a clean environment, like virtualenv,
then setup tries to import huxley to get version information before the
dependencies are install.  This puts setup into a catch-22 as importing
huxley also tries to input uninstalled dependencies.

Sample test code to verify issue and fix ...

```
$ mkdir install-huxley-test
$ cd install-huxley-test

~/install-huxley-test $ git clone git@github.com:emanlove/huxley.git emanlove
```

First revert my fix to show issue

```
~/install-huxley-test $ cd emanlove
~/install-huxley-test/emanlove $ git checkout HEAD^ setup.py
~/install-huxley-test/emanlove $ cd ..

~/install-huxley-test $ virtualenv -p /usr/bin/python2.6 --no-site-packages clean-python-env
~/install-huxley-test $ source ~/clean-python-env/bin/activate
(clean-python-env) ~/install-huxley-test $ cd emanlove
(clean-python-env) ~/install-huxley-test/emanlove $ python setup.py install

(clean-python-env) ~/install-huxley-test/emanlove $ deactivate
```

Reapply my fix and regenerate clean virtualenv

```
~/install-huxley-test/emanlove $ git checkout HEAD setup.py
~/install-huxley-test/emanlove $ cd ..

~/install-huxley-test $ virtualenv -p /usr/bin/python2.6 --no-site-packages clean-python-env
~/install-huxley-test $ source ~/clean-python-env/bin/activate
(clean-python-env) ~/install-huxley-test $ cd emanlove
(clean-python-env) ~/install-huxley-test/emanlove $ python setup.py install
```

Note I am working on signing CLA via directly signing the Word document as I don't have a FB account.
