### PR TITLE
Code modified to make browser as a configurable property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Integration tests sometimes get a bad rap for testing too much at once. We've fo
 * **Don't test a live app. Use mocking to make your components reliable instead.** If you hit your live app, failures in any number of places could trigger false failures in your UI tests. Instead of hitting a real URL in your app, **create a dedicated test URL** for Huxley to hit that uses mocking (and perhaps dependency injection) to isolate your UI component as much as possible. Huxley is completely unopinionated; use whatever tools you want to do this.
 * **Test a small unit of functionality.** You should try to isolate your UI into modular components and test each one individually. Additionally, try to test one interaction per Huxley test so that when it fails, it's easy to tell exactly which interaction is problematic and it's faster to re-run it.
 
-## Techincal FAQ
+## Technical FAQ
 
 ### Why does Huxley stop recording when I navigate away from the page?
 
@@ -112,11 +112,12 @@ You can set the `HUXLEY_WEBDRIVER_LOCAL` environment variable to tell Huxley whi
 
 You can add a `browser` setting to your `Huxleyfile`(valid values: chrome,firefox,ie,opera). The default is `firefox`.
 Just make sure you have appropriate webdriver installed and available in PATH.
-## Philosophical FAQ
 
 ## Can I test responsive design?
 
 Of course! Simply add a `screensize` setting to your `Huxleyfile`. The default is `screensize=1024x768`.
+
+## Philosophical FAQ
 
 ### Why would you use this instead of unit testing?
 

--- a/README.md
+++ b/README.md
@@ -108,11 +108,15 @@ It's usually best if you use an image comparison tool like [Kaleidoscope](http:/
 
 You can set the `HUXLEY_WEBDRIVER_LOCAL` environment variable to tell Huxley which webdriver URL to use for `--record` mode. You can set the `HUXLEY_WEBDRIVER_REMOTE` environment variable to tell Huxley which webdriver URL to use for screenshots and playback. Usually you only need to use this when working in a team setting such that everyone's screenshots are taken on the same machine configuration (otherwise they'll change depending on who ran them last).
 
+### How do I run test on a different browser than firefox?
+
+You can add a `browser` setting to your `Huxleyfile`(valid values: chrome,firefox,ie,opera). The default is `firefox`.
+Just make sure you have appropriate webdriver installed and available in PATH.
+## Philosophical FAQ
+
 ## Can I test responsive design?
 
 Of course! Simply add a `screensize` setting to your `Huxleyfile`. The default is `screensize=1024x768`.
-
-## Philosophical FAQ
 
 ### Why would you use this instead of unit testing?
 

--- a/huxley/cmdline.py
+++ b/huxley/cmdline.py
@@ -119,6 +119,10 @@ def _main(
                 'screensize',
                 '1024x768'
             )
+            browser = test_config.get(
+                'browser',
+                'firefox'
+            )
             if record:
                 r = huxleymain(
                     url,
@@ -127,7 +131,8 @@ def _main(
                     local=LOCAL_WEBDRIVER_URL,
                     remote=REMOTE_WEBDRIVER_URL,
                     record=True,
-                    screensize=screensize
+                    screensize=screensize,
+                    browser=browser
                 )
             else:
                 r = huxleymain(
@@ -138,7 +143,8 @@ def _main(
                     sleepfactor=sleepfactor,
                     autorerecord=not playback_only,
                     save_diff=save_diff,
-                    screensize=screensize
+                    screensize=screensize,
+                    browser=browser
                 )
             new_screenshots = new_screenshots or (r != 0)
             print


### PR DESCRIPTION
Two changes:
1.)  huxley/cmdline.py modified to accommodate browser as a setting parameter so that we can define which browser to use for tests.
2.) README.md's Technical FAQ section modified to include description for above mentioned new setting parameter.
