### PR TITLE
huxley improment

### DIFF
--- a/huxley/cmdline.py
+++ b/huxley/cmdline.py
@@ -58,6 +58,11 @@ DEFAULTS = json.loads(os.environ.get('HUXLEY_DEFAULTS', 'null'))
         'flag',
         'e'
     ),
+    his_mode=plac.Annotation(
+        'run in history mode, you will get all screenshot png by each time',
+        'flag',
+        'H'
+    ),
     version=plac.Annotation(
         'Get the current version',
         'flag',
@@ -70,6 +75,7 @@ def _main(
     record=False,
     playback_only=False,
     save_diff=False,
+    his_mode=False,
     version=False
 ):
     if version:
@@ -127,6 +133,7 @@ def _main(
                     local=LOCAL_WEBDRIVER_URL,
                     remote=REMOTE_WEBDRIVER_URL,
                     record=True,
+                    his_mode=his_mode,
                     screensize=screensize
                 )
             else:
@@ -138,6 +145,7 @@ def _main(
                     sleepfactor=sleepfactor,
                     autorerecord=not playback_only,
                     save_diff=save_diff,
+                    his_mode=his_mode,
                     screensize=screensize
                 )
             new_screenshots = new_screenshots or (r != 0)

--- a/huxley/cmdline.py
+++ b/huxley/cmdline.py
@@ -22,6 +22,7 @@ import plac
 
 from huxley.main import main as huxleymain
 from huxley.version import __version__
+from huxley.gentestcase import GenTestCase
 
 class ExitCodes(object):
     OK = 0
@@ -40,6 +41,13 @@ DEFAULTS = json.loads(os.environ.get('HUXLEY_DEFAULTS', 'null'))
         'Test file(s) to use',
         'option',
         'f',
+        str,
+        metavar='GLOB'
+    ),
+    testcasename=plac.Annotation(
+        'create testcase',
+        'option',
+        'c',
         str,
         metavar='GLOB'
     ),
@@ -76,11 +84,17 @@ def _main(
     playback_only=False,
     save_diff=False,
     his_mode=False,
-    version=False
+    version=False,
+    testcasename=None
 ):
     if version:
         print 'Huxley ' + __version__
         return ExitCodes.OK
+
+    if testcasename:
+        print 'create testcase %s' % testcasename
+        GenTestCase(testcasename).gen()
+        return
 
     testfiles = glob.glob(testfile)
     if len(testfiles) == 0:

--- a/huxley/consts.py
+++ b/huxley/consts.py
@@ -12,7 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime
+
 class TestRunModes(object):
-    RECORD = 1
-    RERECORD = 2
-    PLAYBACK = 3
+    RECORD = 0x01
+    RERECORD = 0x02
+    PLAYBACK = 0x04
+    HISRECORD = 0x08
+
+class TestRunStartTime(object):
+    _instance = None
+    _start_time = None
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            cls._instance = super(TestRunStartTime, cls).__new__(
+                                cls, *args, **kwargs)
+            cls._start_time = datetime.now()
+        return cls._instance
+
+    @classmethod
+    def get_start_time(cls):
+        return cls._start_time
+

--- a/huxley/errors.py
+++ b/huxley/errors.py
@@ -1,2 +1,9 @@
 class TestError(RuntimeError):
-    pass
+
+    def __init__(self, message, errorlist=[]):
+        self.message = message
+        self.errorlist = errorlist
+
+    def __str__(self):
+        return repr(self.message + '\n' + '\n'.join([str(item) for item in self.errorlist]))
+

--- a/huxley/gentestcase.py
+++ b/huxley/gentestcase.py
@@ -27,7 +27,7 @@ class GenTestCase(object):
             class %sTestCase(TestCase, HuxleyTestCase):
                 pass
 
-            """ % self._project_name
+            """ % self._project_name.capitalize()
         self._conf_content = """
             [%s]
             url=http://github.com/facebook/huxley

--- a/huxley/gentestcase.py
+++ b/huxley/gentestcase.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+import os
+import errno
+
+class GenTestCase(object):
+    """auto gen unittest testcase
+
+    for exp:
+    -->GenTestCase('sherlock').gen_testcase_py()
+       it'will create test_sherlock folder and test_sherlock/test_sherlock.py
+    -->GenTestCase('sherlock').gen_conf()
+       it'will create test_sherlock folder and test_sherlock/Huxleyfile.conf
+    """
+
+    def __init__(self, project_name):
+        self._project_name = project_name
+        self._project_path = 'test_' + self._project_name
+        self._testcase_py_path = os.path.join(self._project_path, "test_%s.py" % self._project_name)
+        self._conf_path = os.path.join(self._project_path, "Huxleyfile.conf")
+        self._testcase_py_content = """
+            # -*- coding: utf-8 -*-
+
+            from unittest import TestCase
+            from huxley.huxleytest import HuxleyTestCase
+
+            class %sTestCase(TestCase, HuxleyTestCase):
+                pass
+
+            """ % self._project_name
+        self._conf_content = """
+            [%s]
+            url=http://github.com/facebook/huxley
+
+            """ % self._project_name
+
+        #mkdir -p project_name
+        try:
+            os.makedirs(self._project_path)
+        except OSError as exc: # Python >2.5
+            if exc.errno == errno.EEXIST and os.path.isdir(self._project_path):
+                pass
+            else: raise
+
+    def gen(self):
+        self.gen_testcase_py()
+        self.gen_conf()
+
+    def gen_testcase_py(self):
+        with open(self._testcase_py_path, 'w+') as fp:
+            lines = [line[12:]+'\n' for line in self._testcase_py_content.splitlines() if line]
+            fp.writelines(lines)
+
+    def gen_conf(self):
+        with open(self._conf_path, 'w+') as fp:
+            lines = [line[12:]+'\n' for line in self._conf_content.splitlines() if line]
+            fp.writelines(lines)

--- a/huxley/huxleytest.py
+++ b/huxley/huxleytest.py
@@ -1,0 +1,176 @@
+#!/bin/env python
+# -*- coding: utf-8 -*-
+#Filename:  huxleytest.py
+#Date:      2013-08-29
+
+import os
+import sys
+import glob
+import json
+import urlparse
+import ConfigParser
+
+from huxley.errors import TestError
+from huxley.main import main as huxleymain
+
+# Python unittest integration. These fail when the screen shots change, and they
+# will pass the next time since they diff by last run result screen shots.
+
+DEFAULTS = json.loads(os.environ.get('HUXLEY_DEFAULTS', 'null'))
+
+class HuxleyConfig(object):
+    """only support one section
+
+    just for Huxleyfile.conf
+
+    [toggle]
+    url=http://192.168.159.131:8000/toggle.html
+    filename=toggle.huxley
+    sleepfactor=1.0
+    postdata=null
+    screensize=1024x768
+
+    """
+
+    def __init__(self, config_file ='Huxleyfile.conf'):
+        self._config_file = config_file
+
+        config = ConfigParser.SafeConfigParser(
+            defaults=DEFAULTS,
+            allow_no_value=True
+        )
+        config.read(self._config_file)
+        testname = config.sections()[0]
+
+        test_config = dict(config.items(testname))
+        self._url = config.get(testname, 'url')
+
+        default_filename = os.path.join(
+            os.path.dirname(self._config_file),
+            testname + '.huxley'
+        )
+        self._run_dir = test_config.get(
+            'filename',
+            default_filename
+        )
+        self._sleepfactor = float(test_config.get(
+            'sleepfactor',
+            1.0
+        ))
+        self._postdata = test_config.get(
+            'postdata'
+        )
+        self._screensize = test_config.get(
+            'screensize',
+            '1024x768'
+        )
+
+    @property
+    def url(self):
+        return  self._url
+
+    @property
+    def run_dir(self):
+        return  self._run_dir
+
+    @property
+    def sleepfactor(self):
+        return  self._sleepfactor
+
+    @property
+    def postdata(self):
+        return  self._postdata
+
+    @property
+    def screensize(self):
+        return  self._screensize
+
+
+class HuxleyTestCase(object):
+    """ HuxleyTest base class
+
+        you can inherit HuxleyTestCase for your own ui test
+        by default,you just do like:
+            class OwnHuxleyTestCase(unittest.TestCase, HuxleyTestCase):
+                pass
+
+        if you want to do something before or end testing,just do like:
+            class OwnHuxleyTestCase(unittest.TestCase, HuxleyTestCase):
+
+                def setUp(self):
+                    ...
+                def tearDown(self):
+                    ...
+
+        if you want to control test yourself, just overwrite test_huxley_base() function:
+            class OwnHuxleyTestCase(unittest,TestCase, HuxleyTestCase):
+
+                def test_huxley_base(self):
+                    ...
+
+    """
+    recording = False
+    playback_only = False
+    local_webdriver_url = os.environ.get('HUXLEY_WEBDRIVER_LOCAL', 'http://192.168.159.130:4444/wd/hub')
+    remote_webdriver_url = os.environ.get('HUXLEY_WEBDRIVER_REMOTE', 'http://192.168.159.130:4444/wd/hub')
+    test_confirm_url = os.environ.get('HUXLEYVIEW_URL', 'http://192.168.159.131:9999/huxley/')
+
+    def test_huxley_base(self):
+        test_error_list = []
+        i_dir = os.path.dirname(sys.modules[self.__class__.__module__].__file__)
+        msg = """
+               # Okkkkkkkkkkkkkkkkk,Let'party------------------------
+               #
+               #                 _   /|          Running Huxley test:%s
+               #                 │
+               #                 \'o.O'
+               #                 │In [3]:
+               #                 =(___)=
+               # │---------------------------------------------------
+                                   U
+              """ % os.path.basename(i_dir)
+        print '\n'.join([line.strip() for line in msg.splitlines()])
+
+        #foreach all dirs, run each test
+        huxley_configs = glob.glob(os.path.join(i_dir, '*.conf'))
+        if len(huxley_configs) > 1:
+            raise ValueError('only support one conf file, current dir:%s has %d files'
+                    % (i_dir, len(huxley_configs)))
+        if len(huxley_configs) < 1:
+            raise ValueError('None conf file' % (i_dir, len(huxley_configs)))
+        config = HuxleyConfig(os.path.join(os.path.realpath(i_dir), os.path.basename(huxley_configs[0])))
+
+        try:
+            huxleymain(
+                    url=config.url,
+                    filename=config.run_dir,
+                    postdata=config.postdata,
+                    sleepfactor=config.sleepfactor,
+                    screensize=config.screensize,
+                    remote=self.remote_webdriver_url,
+                    save_diff=True,
+                    his_mode=True
+                )
+        except TestError, e:
+            for ierror in e.errorlist:
+                timestamp = ierror['timestamp'].strftime('%Y%m%d%H%M%S')
+                errmsg = """
+                           ------------------------------------------------------------------------------------------------
+                             _____ ____  ____   ___  ____
+                            | ____|  _ \|  _ \ / _ \|  _ \
+                            |  _| | |_) | |_) | | | | |_) |
+                            | |___|  _ <|  _ <| |_| |  _ <
+                            |_____|_| \_\_| \_\\___/|_| \_\
+
+                            Test_URL:%s
+                            Errmsg:%s
+                            Step:%s
+                            Confirm URL:%s
+                           ------------------------------------------------------------------------------------------------
+
+                         """  % (config.url, ierror['error'], ierror['step'],
+                                    urlparse.urljoin(self.test_confirm_url, os.path.join(str(item[0]), timestamp, timestamp)))
+                print '\n'.join([line.strip() for line in errmsg.splitlines()])
+                test_error_list.append(ierror)
+
+        self.assertEqual(len(test_error_list), 0, 'New screenshots were taken and written. Please be sure to review and check in.')

--- a/huxley/huxleytest.py
+++ b/huxley/huxleytest.py
@@ -4,6 +4,7 @@
 #Date:      2013-08-29
 
 import os
+import re
 import sys
 import glob
 import json
@@ -171,7 +172,8 @@ class HuxleyTestCase(object):
                          """  % (config.url, ierror['error'], ierror['step'],
                                  urlparse.urljoin(self.test_confirm_url,
                                                   os.path.join(os.path.relpath(i_dir, os.getcwd()),
-                                                               os.path.basename(i_dir).lstrip('test_') +'.huxley',
+                                                               re.match('^test_(.*)',
+                                                                   os.path.basename(i_dir)).groups()[0] +'.huxley',
                                                                timestamp, timestamp)
                                                   )
                                 )

--- a/huxley/huxleytest.py
+++ b/huxley/huxleytest.py
@@ -137,7 +137,7 @@ class HuxleyTestCase(object):
             raise ValueError('only support one conf file, current dir:%s has %d files'
                     % (i_dir, len(huxley_configs)))
         if len(huxley_configs) < 1:
-            raise ValueError('None conf file' % (i_dir, len(huxley_configs)))
+            raise ValueError('None conf file, current dir:%s has %d files' % (i_dir, len(huxley_configs)))
         config = HuxleyConfig(os.path.join(os.path.realpath(i_dir), os.path.basename(huxley_configs[0])))
 
         try:
@@ -169,8 +169,8 @@ class HuxleyTestCase(object):
                            ------------------------------------------------------------------------------------------------
 
                          """  % (config.url, ierror['error'], ierror['step'],
-                                    urlparse.urljoin(self.test_confirm_url, os.path.join(str(item[0]), timestamp, timestamp)))
+                                    urlparse.urljoin(self.test_confirm_url, os.path.join(str(ierror[0]), timestamp, timestamp)))
                 print '\n'.join([line.strip() for line in errmsg.splitlines()])
                 test_error_list.append(ierror)
 
-        self.assertEqual(len(test_error_list), 0, 'New screenshots were taken and written. Please be sure to review and check in.')
+        assert(len(test_error_list)==0), 'New screenshots were taken and written. Please be sure to review and check in.'

--- a/huxley/huxleytest.py
+++ b/huxley/huxleytest.py
@@ -169,7 +169,8 @@ class HuxleyTestCase(object):
                            ------------------------------------------------------------------------------------------------
 
                          """  % (config.url, ierror['error'], ierror['step'],
-                                    urlparse.urljoin(self.test_confirm_url, os.path.join(str(ierror[0]), timestamp, timestamp)))
+                                    urlparse.urljoin(self.test_confirm_url,
+                                        os.path.join(os.path.relpath(i_dir, os.getcwd()), timestamp, timestamp)))
                 print '\n'.join([line.strip() for line in errmsg.splitlines()])
                 test_error_list.append(ierror)
 

--- a/huxley/huxleytest.py
+++ b/huxley/huxleytest.py
@@ -111,9 +111,9 @@ class HuxleyTestCase(object):
     """
     recording = False
     playback_only = False
-    local_webdriver_url = os.environ.get('HUXLEY_WEBDRIVER_LOCAL', 'http://192.168.159.130:4444/wd/hub')
-    remote_webdriver_url = os.environ.get('HUXLEY_WEBDRIVER_REMOTE', 'http://192.168.159.130:4444/wd/hub')
-    test_confirm_url = os.environ.get('HUXLEYVIEW_URL', 'http://192.168.159.131:9999/huxley/')
+    local_webdriver_url = os.environ.get('HUXLEY_WEBDRIVER_LOCAL', 'http://172.16.11.74:8888/wd/hub')
+    remote_webdriver_url = os.environ.get('HUXLEY_WEBDRIVER_REMOTE', 'http://172.16.11.74:8888/wd/hub')
+    test_confirm_url = os.environ.get('HUXLEYVIEW_URL', 'http://172.16.11.34:9999/huxley/')
 
     def test_huxley_base(self):
         test_error_list = []
@@ -157,10 +157,10 @@ class HuxleyTestCase(object):
                 errmsg = """
                            ------------------------------------------------------------------------------------------------
                              _____ ____  ____   ___  ____
-                            | ____|  _ \|  _ \ / _ \|  _ \
+                            | ____|  _ \|  _ \ / _ \|  _
                             |  _| | |_) | |_) | | | | |_) |
                             | |___|  _ <|  _ <| |_| |  _ <
-                            |_____|_| \_\_| \_\\___/|_| \_\
+                            |_____|_| \_\_| \_ ___/|_| \_
 
                             Test_URL:%s
                             Errmsg:%s
@@ -169,8 +169,12 @@ class HuxleyTestCase(object):
                            ------------------------------------------------------------------------------------------------
 
                          """  % (config.url, ierror['error'], ierror['step'],
-                                    urlparse.urljoin(self.test_confirm_url,
-                                        os.path.join(os.path.relpath(i_dir, os.getcwd()), timestamp, timestamp)))
+                                 urlparse.urljoin(self.test_confirm_url,
+                                                  os.path.join(os.path.relpath(i_dir, os.getcwd()),
+                                                               os.path.basename(i_dir).lstrip('test_') +'.huxley',
+                                                               timestamp, timestamp)
+                                                  )
+                                )
                 print '\n'.join([line.strip() for line in errmsg.splitlines()])
                 test_error_list.append(ierror)
 

--- a/huxley/login.py
+++ b/huxley/login.py
@@ -1,0 +1,20 @@
+#!/bin/env python
+# -*- coding: utf-8 -*-
+#Filename:  login_handler.py
+#Date:      2013-08-30
+
+from selenium.common.exceptions import NoSuchElementException
+
+def login_handle(d, url):
+    """Custom your own login func
+
+    before you visit url, you must use login_handle to login
+    """
+    try:
+        d.get(url)
+        d.find_element_by_id('id_username').send_keys('admin')
+        d.find_element_by_id('id_password').send_keys('netis')
+        d.find_element_by_xpath("//input[@type='submit']").click()
+    except NoSuchElementException:
+        pass
+

--- a/huxley/main.py
+++ b/huxley/main.py
@@ -22,6 +22,7 @@ import plac
 from selenium import webdriver
 
 from huxley.run import TestRun
+from huxley.consts import TestRunStartTime
 from huxley.errors import TestError
 
 DRIVERS = {
@@ -54,7 +55,8 @@ CAPABILITIES = {
     diffcolor=plac.Annotation('Diff color for errors (i.e. 0,255,0)', 'option', 'd', str, metavar='RGB'),
     screensize=plac.Annotation('Width and height for screen (i.e. 1024x768)', 'option', 's', metavar='SIZE'),
     autorerecord=plac.Annotation('Playback test and automatically rerecord if it fails', 'flag', 'a'),
-    save_diff=plac.Annotation('Save information about failures as last.png and diff.png', 'flag', 'e')
+    save_diff=plac.Annotation('Save information about failures as last.png and diff.png', 'flag', 'e'),
+    his_mode=plac.Annotation('run in history mode, you will get all screenshot png by each time', 'flag', 'H')
 )
 def main(
         url,
@@ -69,7 +71,10 @@ def main(
         diffcolor='0,255,0',
         screensize='1024x768',
         autorerecord=False,
-        save_diff=False):
+        save_diff=False,
+        his_mode=False):
+
+    print "start time:%s..." % TestRunStartTime().get_start_time().strftime('%Y-%m-%d %H:%M:%S')
 
     if postdata:
         if postdata == '-':
@@ -106,14 +111,14 @@ def main(
                 with open(jsonfile, 'w') as f:
                     f.write(
                         jsonpickle.encode(
-                            TestRun.record(local_d, d, (url, postdata), screensize, filename, diffcolor, sleepfactor, save_diff)
+                            TestRun.record(local_d, d, (url, postdata), screensize, filename, diffcolor, sleepfactor, save_diff, his_mode)
                         )
                     )
             print 'Test recorded successfully'
             return 0
         elif rerecord:
             with open(jsonfile, 'r') as f:
-                TestRun.rerecord(jsonpickle.decode(f.read()), filename, (url, postdata), d, sleepfactor, diffcolor, save_diff)
+                TestRun.rerecord(jsonpickle.decode(f.read()), filename, (url, postdata), d, sleepfactor, diffcolor, save_diff, his_mode)
                 print 'Test rerecorded successfully'
                 return 0
         elif autorerecord:
@@ -121,17 +126,17 @@ def main(
                 test = jsonpickle.decode(f.read())
             try:
                 print 'Running test to determine if we need to rerecord'
-                TestRun.playback(test, filename, (url, postdata), d, sleepfactor, diffcolor, save_diff)
+                TestRun.playback(test, filename, (url, postdata), d, sleepfactor, diffcolor, save_diff, his_mode)
                 print 'Test played back successfully'
                 return 0
             except TestError:
                 print 'Test failed, rerecording...'
-                TestRun.rerecord(test, filename, (url, postdata), d, sleepfactor, diffcolor, save_diff)
+                TestRun.rerecord(test, filename, (url, postdata), d, sleepfactor, diffcolor, save_diff, his_mode)
                 print 'Test rerecorded successfully'
                 return 2
         else:
             with open(jsonfile, 'r') as f:
-                TestRun.playback(jsonpickle.decode(f.read()), filename, (url, postdata), d, sleepfactor, diffcolor, save_diff)
+                TestRun.playback(jsonpickle.decode(f.read()), filename, (url, postdata), d, sleepfactor, diffcolor, save_diff, his_mode)
                 print 'Test played back successfully'
                 return 0
 

--- a/huxley/main.py
+++ b/huxley/main.py
@@ -20,6 +20,7 @@ import sys
 import jsonpickle
 import plac
 from selenium import webdriver
+from selenium.common.exceptions import UnexpectedAlertPresentException
 
 from huxley.run import TestRun
 from huxley.consts import TestRunStartTime
@@ -101,7 +102,7 @@ def main(
     diffcolor = tuple(int(x) for x in diffcolor.split(','))
     jsonfile = os.path.join(filename, 'record.json')
 
-    with contextlib.closing(d):
+    try:
         if record:
             if local:
                 local_d = webdriver.Remote(local, CAPABILITIES[browser])
@@ -139,6 +140,13 @@ def main(
                 TestRun.playback(jsonpickle.decode(f.read()), filename, (url, postdata), d, sleepfactor, diffcolor, save_diff, his_mode)
                 print 'Test played back successfully'
                 return 0
+    finally:
+        try:
+            d.close()
+        except UnexpectedAlertPresentException:
+            print "auto accept alert"
+            alert = d.switch_to_alert()
+            alert.accept()
 
 if __name__ == '__main__':
     sys.exit(plac.call(main))

--- a/huxley/run.py
+++ b/huxley/run.py
@@ -20,7 +20,7 @@ from selenium.common.exceptions import UnexpectedAlertPresentException
 
 from huxley.consts import TestRunModes, TestRunStartTime
 from huxley.errors import TestError
-from huxley.steps import ScreenshotTestStep, ClickTestStep, KeyTestStep, DragAndDropTestStep
+from huxley.steps import ScreenshotTestStep, ClickTestStep, KeyTestStep, DragAndDropTestStep, MouseDownTestStep
 
 def get_post_js(url, postdata):
     markup = '<form method="post" action="%s">' % url
@@ -174,6 +174,7 @@ window._getHuxleyEvents = function() { return events; };
                 steps.append(KeyTestStep(timestamp - start_time, params))
 
             elif type == 'mousedown':
+                steps.append(MouseDownTestStep(timestamp - start_time, params))
                 del mouse_action_stack[:]
                 mouse_action_stack.append({'action':'mousedown', 'offtime':(timestamp -start_time), 'position':params})
             elif type == 'mousemove':
@@ -184,7 +185,8 @@ window._getHuxleyEvents = function() { return events; };
                 mouse_actions = [item['action'] for item in mouse_action_stack]
                 if 'mousedown' in mouse_actions:
                     mouse_down_index = mouse_actions.index('mousedown')
-                    if mouse_down_index<len(mouse_action_stack) - 1:
+                    if (mouse_down_index<len(mouse_action_stack) - 1) and \
+                            (mouse_action_stack[mouse_down_index]['position']<>params):
                         steps.append(DragAndDropTestStep(mouse_action_stack[mouse_down_index]['offtime'],
                                                      mouse_action_stack[mouse_down_index]['position'],
                                                      params))

--- a/huxley/run.py
+++ b/huxley/run.py
@@ -16,6 +16,7 @@ import json
 import operator
 import os
 import time
+from selenium.common.exceptions import UnexpectedAlertPresentException
 
 from huxley.consts import TestRunModes, TestRunStartTime
 from huxley.errors import TestError
@@ -42,8 +43,14 @@ def get_post_js(url, postdata):
 
 def navigate(d, url):
     href, postdata = url
-    d.get('about:blank')
-    d.refresh()
+    try:
+        d.get('about:blank')
+        d.refresh()
+    except UnexpectedAlertPresentException:
+        print "auto accept alert"
+        alert = d.switch_to_alert()
+        alert.accept()
+
     try:
         from huxley.login import login_handle
         login_handle(d, href)
@@ -183,8 +190,6 @@ window._getHuxleyEvents = function() { return events; };
                                                      params))
 
                 del mouse_action_stack[:]
-            import pprint
-            pprint.pprint(mouse_action_stack)
 
         steps.sort(key=operator.attrgetter('offset_time'))
 

--- a/huxley/run.py
+++ b/huxley/run.py
@@ -17,7 +17,7 @@ import operator
 import os
 import time
 
-from huxley.consts import TestRunModes
+from huxley.consts import TestRunModes, TestRunStartTime
 from huxley.errors import TestError
 from huxley.steps import ScreenshotTestStep, ClickTestStep, KeyTestStep
 
@@ -108,12 +108,10 @@ class TestRun(object):
                 step.execute(self)
                 last_offset_time = step.offset_time
             except TestError,e:
-                play_errors.append({'error':e, 'step':step.index})
+                play_errors.append({'error':e, 'step':step.index, 'timestamp':TestRunStartTime().get_start_time()})
                 continue
         if play_errors:
-            for item in play_errors:
-                print "!!!step %d playback Err" % item['step']
-            raise TestError("%d steps err" % len(play_errors))
+            raise TestError("%d errs" % len(play_errors), play_errors)
 
 
     @classmethod

--- a/huxley/steps.py
+++ b/huxley/steps.py
@@ -45,6 +45,18 @@ class ClickTestStep(TestStep):
             'document.elementFromPoint(%d, %d).click();' % (self.pos[0], self.pos[1])
         )
 
+class MouseDownTestStep(TestStep):
+    def __init__(self, offset_time, pos):
+        super(MouseDownTestStep, self).__init__(offset_time)
+        self.pos = pos
+
+    def execute(self, run):
+        print '  mousedown', self.pos
+        mouse_down = ActionChains(run.d)
+        mouse_down.move_to_element_with_offset(run.d.find_element_by_xpath('//body'), 0, 0)\
+                    .move_by_offset(self.pos[0], self.pos[1])\
+                    .click_and_hold().release().perform()
+
 class DragAndDropTestStep(TestStep):
     CLICK_ID = '_huxleyDragAndDrop'
 

--- a/huxley/steps.py
+++ b/huxley/steps.py
@@ -124,12 +124,12 @@ class ScreenshotTestStep(TestStep):
             run_time = TestRunStartTime.get_start_time()
         history_run_folders_time = [
                 datetime.strptime(item, '%Y%m%d%H%M%S') for item in os.listdir(run.path) if re.match('\d+', item)]
-        history_run_folders_time = [item for item in history_run_folders_time if item]
+        history_run_folders_time = [item for item in history_run_folders_time if item<>run_time]
 
         if not history_run_folders_time:
             return None
         latest_dir_time = history_run_folders_time[
-            history_run_folders_time.index(min(history_run_folders_time, key=lambda x:(run_time-x).seconds))]
+            history_run_folders_time.index(min(history_run_folders_time, key=lambda x:(run_time-x).total_seconds()))]
 
         return os.path.join(run.path, latest_dir_time.strftime('%Y%m%d%H%M%S'), 'screenshot' + str(self.index) + '.png')
 

--- a/huxley/steps.py
+++ b/huxley/steps.py
@@ -16,6 +16,7 @@ import os
 import re
 import time
 from datetime import datetime
+from selenium.webdriver import ActionChains
 
 from huxley.consts import TestRunModes, TestRunStartTime
 from huxley.errors import TestError
@@ -43,6 +44,23 @@ class ClickTestStep(TestStep):
             'document.elementFromPoint(%d, %d).click();' % (self.pos[0], self.pos[1])
         )
 
+class DragAndDropTestStep(TestStep):
+    CLICK_ID = '_huxleyDragAndDrop'
+
+    def __init__(self, offset_time, mouse_down_pos, mouse_up_pos):
+        super(DragAndDropTestStep, self).__init__(offset_time)
+        self.mouse_down_pos = mouse_down_pos
+        self.mouse_up_pos = mouse_up_pos
+
+    def execute(self, run):
+        print 'Drag and drop', self.mouse_down_pos, self.mouse_up_pos
+        # Work around multiple bugs in WebDriver's implementation of drag and drop
+        drag_and_drop = ActionChains(run.d)
+        drag_and_drop.move_to_element_with_offset(run.d.find_element_by_xpath('//body'), 0, 0)\
+                    .move_by_offset(self.mouse_down_pos[0], self.mouse_down_pos[1])\
+                    .click_and_hold()\
+                    .move_by_offset(self.mouse_up_pos[0]-self.mouse_down_pos[0], self.mouse_up_pos[1]-self.mouse_down_pos[1])\
+                    .release().perform()
 
 class KeyTestStep(TestStep):
     KEY_ID = '_huxleyKey'

--- a/huxley/steps.py
+++ b/huxley/steps.py
@@ -17,6 +17,7 @@ import re
 import time
 from datetime import datetime
 from selenium.webdriver import ActionChains
+from selenium.common.exceptions import MoveTargetOutOfBoundsException
 
 from huxley.consts import TestRunModes, TestRunStartTime
 from huxley.errors import TestError
@@ -56,11 +57,15 @@ class DragAndDropTestStep(TestStep):
         print 'Drag and drop', self.mouse_down_pos, self.mouse_up_pos
         # Work around multiple bugs in WebDriver's implementation of drag and drop
         drag_and_drop = ActionChains(run.d)
-        drag_and_drop.move_to_element_with_offset(run.d.find_element_by_xpath('//body'), 0, 0)\
+        try:
+            drag_and_drop.move_to_element_with_offset(run.d.find_element_by_xpath('//body'), 0, 0)\
                     .move_by_offset(self.mouse_down_pos[0], self.mouse_down_pos[1])\
                     .click_and_hold()\
                     .move_by_offset(self.mouse_up_pos[0]-self.mouse_down_pos[0], self.mouse_up_pos[1]-self.mouse_down_pos[1])\
                     .release().perform()
+        except MoveTargetOutOfBoundsException:
+            print 'Error, move target out of bounds'
+
 
 class KeyTestStep(TestStep):
     KEY_ID = '_huxleyKey'


### PR DESCRIPTION
Dear Pete Hunt:
sorry for my poor English first :)

Huxley is  useful and interesting.I do some static html UI test for my project.And i do something improment. Maybe someone need this,so i pull it..
## 1. add a test mode "history",

in this mode, huxley will save screenshot to a folder named by current datetime after each test.
for exp: this is my 5 tests later
![screenclip](https://f.cloud.github.com/assets/1989073/1113862/c69bde08-1a08-11e3-87af-ddc3efa9bcb2.png)

if you want to use history mode,just record and play in:

``` shell
huxley -r -H
huxley -p -H
```
## 2. add mouse drag and drop support

we can drag and drop element now
## 3.improve run.py->navigate()

sometimes, we'll find alert dialog when close or refresh page,i add UnexpectedAlertPresentException to ignore it.
## 4.add  huxleytest.py to support nosetests better.

Now we can

``` shell
huxley -c facebook
```

to create a testcase for nosetests and this case will run in history mode default,it'll log pretty if fails.
## 5. add login.py-->login_handle

sometimes,send postdata won't login correctly because of redirect, i provide a login_handle for custom own login method.

That's what i changed.
i'd like that it has something useful. 
I''m a beginner on github, so i didn't create branch for this pull request.sorry..
