### PR TITLE
fix browser click event record

### DIFF
--- a/huxley/run.py
+++ b/huxley/run.py
@@ -110,7 +110,7 @@ class TestRun(object):
         d.execute_script('''
 (function() {
 var events = [];
-window.addEventListener('click', function (e) { events.push([+new Date(), 'click', [e.clientX, e.clientY]]); }, true);
+window.addEventListener('mouseup', function (e) { events.push([+new Date(), 'click', [e.clientX, e.clientY]]); }, true);
 window.addEventListener('keyup', function (e) { events.push([+new Date(), 'keyup', String.fromCharCode(e.keyCode)]); }, true);
 window._getHuxleyEvents = function() { return events; };
 })();


### PR DESCRIPTION
`click` registers twice when the clicked item is something wrapped inside a `label`, say a `checkbox`. Being recorded twice means that during the replay, the checkbox is quickly checked and unchecked. `mousedown` fixes this.
