### PR TITLE
Properly handle specified test names

### DIFF
--- a/huxley/cmdline.py
+++ b/huxley/cmdline.py
@@ -143,6 +143,7 @@ def _main(
 
     new_screenshots = threadpool.Flag()
     pool = threadpool.ThreadPool()
+    names = names.split(",")
 
     for file in testfiles:
         msg = 'Running Huxley file: ' + file

--- a/huxley/cmdline.py
+++ b/huxley/cmdline.py
@@ -143,7 +143,8 @@ def _main(
 
     new_screenshots = threadpool.Flag()
     pool = threadpool.ThreadPool()
-    names = names.split(",")
+    if names:
+        names = names.split(",")
 
     for file in testfiles:
         msg = 'Running Huxley file: ' + file


### PR DESCRIPTION
Before, the available tests were just checked against the passed in comma-separated string of test names, and if the test name was found somewhere in that string it would be run. This caused problems when you had two tests like `test` and `bettertest`, because if you passed to run `bettertest`, it runs both `bettertest` and `test` as well (since `test` is a substring of `bettertest`, and thus it will be found in the passed in string `bettertest`).

This fixes the problem by splitting the string of test names on commas (it specifies that the list of tests should be comma-separated in the usage). This way, the `in` below (line 160) checks if the test name is in the list of tests, and doesn't have any weird substring behavior.

I've signed the CLA already. Thanks!
