### PR TITLE
Continue running remaining tests when one fails

### DIFF
--- a/huxley/steps.py
+++ b/huxley/steps.py
@@ -101,6 +101,10 @@ class ScreenshotTestStep(TestStep):
                             )
                         else:
                             raise TestError('Screenshot %s was different.' % self.index)
+                except (TestError, ValueError) as e:
+                    print ' ', e
+                    pass
                 finally:
                     if not run.save_diff:
                         os.unlink(new)
+


### PR DESCRIPTION
This lets us see all of the failing tests rather than just the first failing test. (Super useful when you want to be able to see all that info in the morning!)
